### PR TITLE
feat(messages): add link preview for URLs in messages

### DIFF
--- a/lib/features/messages/data/link_preview_service.dart
+++ b/lib/features/messages/data/link_preview_service.dart
@@ -1,0 +1,315 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+
+import '../../../core/logging/app_logger.dart';
+import '../../../core/networking/api_config.dart';
+import '../../../core/networking/client.dart';
+import '../domain/link_preview.dart';
+
+/// Service for fetching OpenGraph link previews
+///
+/// Fetches metadata from URLs to display rich previews in messages.
+/// Supports caching, timeout handling, and graceful degradation.
+class LinkPreviewService {
+  LinkPreviewService(this._getAccessToken);
+
+  final Future<String?> Function() _getAccessToken;
+
+  /// In-memory cache for link previews (LRU with TTL)
+  final Map<String, _CachedPreview> _cache = {};
+  static const int _maxCacheSize = 100;
+  static const Duration _cacheTtl = Duration(hours: 1);
+  static const Duration _fetchTimeout = Duration(seconds: 5);
+
+  /// Fetch link preview for a URL
+  ///
+  /// Returns cached result if available, otherwise fetches from server.
+  /// Returns null if fetch fails or URL is invalid.
+  Future<LinkPreview?> fetchPreview(String url) async {
+    // Validate URL
+    if (!_isValidUrl(url)) {
+      return null;
+    }
+
+    // Check cache first
+    final cached = _getCached(url);
+    if (cached != null) {
+      return cached;
+    }
+
+    try {
+      final preview = await _fetchFromServer(url).timeout(_fetchTimeout);
+      if (preview != null) {
+        _addToCache(url, preview);
+      }
+      return preview;
+    } on TimeoutException {
+      AppLogger.warning('Link preview fetch timed out', data: {'url': url});
+      return null;
+    } catch (e, stackTrace) {
+      AppLogger.error(
+        'Failed to fetch link preview',
+        error: e,
+        stackTrace: stackTrace,
+        data: {'url': url},
+      );
+      return null;
+    }
+  }
+
+  /// Extract URLs from text message
+  static List<String> extractUrls(String text) {
+    final urlPattern = RegExp(
+      r'https?://[^\s<>\[\]{}|\\^`"]+',
+      caseSensitive: false,
+    );
+
+    return urlPattern
+        .allMatches(text)
+        .map((m) => m.group(0)!)
+        .where(_isValidUrl)
+        .toList();
+  }
+
+  /// Check if URL is valid and should have preview fetched
+  static bool _isValidUrl(String url) {
+    try {
+      final uri = Uri.parse(url);
+      if (!uri.hasScheme || !uri.hasAuthority) {
+        return false;
+      }
+      // Skip certain file types that don't have OpenGraph
+      final path = uri.path.toLowerCase();
+      if (path.endsWith('.pdf') ||
+          path.endsWith('.zip') ||
+          path.endsWith('.tar') ||
+          path.endsWith('.gz') ||
+          path.endsWith('.exe') ||
+          path.endsWith('.dmg')) {
+        return false;
+      }
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  Future<LinkPreview?> _fetchFromServer(String url) async {
+    final token = await _getAccessToken();
+
+    // Use files service for URL preview endpoint
+    final uri = Uri.parse(
+      '${ApiConfig.filesBaseUrl}/v1/preview',
+    ).replace(queryParameters: {'url': url});
+
+    final response = await http.get(
+      uri,
+      headers: {
+        if (token != null && token.isNotEmpty) 'Authorization': 'Bearer $token',
+        'Accept': 'application/json',
+      },
+    );
+
+    if (response.statusCode == 200) {
+      final json = jsonDecode(response.body) as Map<String, dynamic>;
+      return LinkPreview.fromJson(json);
+    }
+
+    // Fallback: Try to fetch directly and parse OpenGraph tags
+    return _fetchDirectly(url);
+  }
+
+  /// Fallback method to fetch OpenGraph tags directly from the URL
+  Future<LinkPreview?> _fetchDirectly(String url) async {
+    try {
+      final response = await http
+          .get(
+            Uri.parse(url),
+            headers: {
+              'User-Agent':
+                  'Mozilla/5.0 (compatible; LinkPreviewBot/1.0; +https://antinvestor.com)',
+            },
+          )
+          .timeout(_fetchTimeout);
+
+      if (response.statusCode != 200) {
+        return null;
+      }
+
+      final html = response.body;
+      return _parseOpenGraphTags(url, html);
+    } catch (e) {
+      AppLogger.debug('Direct fetch failed for $url: $e');
+      return null;
+    }
+  }
+
+  /// Parse OpenGraph tags from HTML
+  LinkPreview? _parseOpenGraphTags(String url, String html) {
+    String? title;
+    String? description;
+    String? imageUrl;
+    String? siteName;
+    String? favicon;
+
+    // Parse og:title
+    final titleMatch = RegExp(
+      '''<meta[^>]*property=["']og:title["'][^>]*content=["']([^"']*)["']''',
+      caseSensitive: false,
+    ).firstMatch(html);
+    title = titleMatch?.group(1);
+
+    // Fallback to <title> tag
+    if (title == null || title.isEmpty) {
+      final htmlTitleMatch = RegExp(
+        '<title[^>]*>([^<]*)</title>',
+        caseSensitive: false,
+      ).firstMatch(html);
+      title = htmlTitleMatch?.group(1)?.trim();
+    }
+
+    // Parse og:description
+    final descMatch = RegExp(
+      '''<meta[^>]*property=["']og:description["'][^>]*content=["']([^"']*)["']''',
+      caseSensitive: false,
+    ).firstMatch(html);
+    description = descMatch?.group(1);
+
+    // Fallback to meta description
+    if (description == null || description.isEmpty) {
+      final metaDescMatch = RegExp(
+        '''<meta[^>]*name=["']description["'][^>]*content=["']([^"']*)["']''',
+        caseSensitive: false,
+      ).firstMatch(html);
+      description = metaDescMatch?.group(1);
+    }
+
+    // Parse og:image
+    final imageMatch = RegExp(
+      '''<meta[^>]*property=["']og:image["'][^>]*content=["']([^"']*)["']''',
+      caseSensitive: false,
+    ).firstMatch(html);
+    imageUrl = imageMatch?.group(1);
+
+    // Parse og:site_name
+    final siteMatch = RegExp(
+      '''<meta[^>]*property=["']og:site_name["'][^>]*content=["']([^"']*)["']''',
+      caseSensitive: false,
+    ).firstMatch(html);
+    siteName = siteMatch?.group(1);
+
+    // Parse favicon
+    final faviconMatch = RegExp(
+      '''<link[^>]*rel=["'](?:shortcut )?icon["'][^>]*href=["']([^"']*)["']''',
+      caseSensitive: false,
+    ).firstMatch(html);
+    favicon = faviconMatch?.group(1);
+
+    // Resolve relative URLs
+    final baseUri = Uri.parse(url);
+    if (imageUrl != null && !imageUrl.startsWith('http')) {
+      imageUrl = baseUri.resolve(imageUrl).toString();
+    }
+    if (favicon != null && !favicon.startsWith('http')) {
+      favicon = baseUri.resolve(favicon).toString();
+    }
+
+    // Need at least a title to return a preview
+    if (title == null || title.isEmpty) {
+      return null;
+    }
+
+    return LinkPreview(
+      url: url,
+      title: _decodeHtmlEntities(title),
+      description: description != null
+          ? _decodeHtmlEntities(description)
+          : null,
+      imageUrl: imageUrl,
+      siteName: siteName ?? baseUri.host,
+      favicon: favicon,
+    );
+  }
+
+  /// Decode common HTML entities
+  String _decodeHtmlEntities(String text) {
+    return text
+        .replaceAll('&amp;', '&')
+        .replaceAll('&lt;', '<')
+        .replaceAll('&gt;', '>')
+        .replaceAll('&quot;', '"')
+        .replaceAll('&#39;', "'")
+        .replaceAll('&nbsp;', ' ')
+        .replaceAll('&#x27;', "'")
+        .replaceAll('&#x2F;', '/');
+  }
+
+  LinkPreview? _getCached(String url) {
+    final cached = _cache[url];
+    if (cached == null) return null;
+
+    // Check if expired
+    if (DateTime.now().difference(cached.timestamp) > _cacheTtl) {
+      _cache.remove(url);
+      return null;
+    }
+
+    return cached.preview;
+  }
+
+  void _addToCache(String url, LinkPreview preview) {
+    // Evict oldest entries if cache is full
+    if (_cache.length >= _maxCacheSize) {
+      final oldest = _cache.entries.reduce(
+        (a, b) => a.value.timestamp.isBefore(b.value.timestamp) ? a : b,
+      );
+      _cache.remove(oldest.key);
+    }
+
+    _cache[url] = _CachedPreview(preview: preview, timestamp: DateTime.now());
+  }
+
+  /// Clear cache (useful for testing or memory pressure)
+  void clearCache() {
+    _cache.clear();
+  }
+}
+
+class _CachedPreview {
+  _CachedPreview({required this.preview, required this.timestamp});
+  final LinkPreview preview;
+  final DateTime timestamp;
+}
+
+// Provider
+final linkPreviewServiceProvider = Provider<LinkPreviewService>((ref) {
+  final tokenManager = ref.watch(tokenManagerProvider);
+  return LinkPreviewService(() async => tokenManager.accessToken);
+});
+
+/// Provider to fetch link preview for a specific URL
+final linkPreviewProvider = FutureProvider.family<LinkPreview?, String>((
+  ref,
+  url,
+) async {
+  final service = ref.watch(linkPreviewServiceProvider);
+  return service.fetchPreview(url);
+});
+
+/// Provider to extract and fetch previews for all URLs in a message
+final messageLinksPreviewProvider =
+    FutureProvider.family<List<LinkPreview>, String>((ref, text) async {
+      final service = ref.watch(linkPreviewServiceProvider);
+      final urls = LinkPreviewService.extractUrls(text);
+
+      if (urls.isEmpty) {
+        return [];
+      }
+
+      // Only fetch preview for the first URL to avoid overwhelming the UI
+      final preview = await service.fetchPreview(urls.first);
+      return preview != null ? [preview] : [];
+    });

--- a/lib/features/messages/domain/link_preview.dart
+++ b/lib/features/messages/domain/link_preview.dart
@@ -1,0 +1,31 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'link_preview.freezed.dart';
+part 'link_preview.g.dart';
+
+/// Link preview metadata from OpenGraph tags
+@freezed
+abstract class LinkPreview with _$LinkPreview {
+  const factory LinkPreview({
+    /// The original URL
+    required String url,
+
+    /// Page title (og:title or <title>)
+    required String title,
+
+    /// Page description (og:description or meta description)
+    String? description,
+
+    /// Preview image URL (og:image)
+    String? imageUrl,
+
+    /// Site name (og:site_name or domain)
+    String? siteName,
+
+    /// Favicon URL
+    String? favicon,
+  }) = _LinkPreview;
+
+  factory LinkPreview.fromJson(Map<String, dynamic> json) =>
+      _$LinkPreviewFromJson(json);
+}

--- a/lib/features/messages/domain/link_preview.freezed.dart
+++ b/lib/features/messages/domain/link_preview.freezed.dart
@@ -1,0 +1,304 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'link_preview.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$LinkPreview {
+
+/// The original URL
+ String get url;/// Page title (og:title or <title>)
+ String get title;/// Page description (og:description or meta description)
+ String? get description;/// Preview image URL (og:image)
+ String? get imageUrl;/// Site name (og:site_name or domain)
+ String? get siteName;/// Favicon URL
+ String? get favicon;
+/// Create a copy of LinkPreview
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$LinkPreviewCopyWith<LinkPreview> get copyWith => _$LinkPreviewCopyWithImpl<LinkPreview>(this as LinkPreview, _$identity);
+
+  /// Serializes this LinkPreview to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is LinkPreview&&(identical(other.url, url) || other.url == url)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.imageUrl, imageUrl) || other.imageUrl == imageUrl)&&(identical(other.siteName, siteName) || other.siteName == siteName)&&(identical(other.favicon, favicon) || other.favicon == favicon));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,url,title,description,imageUrl,siteName,favicon);
+
+@override
+String toString() {
+  return 'LinkPreview(url: $url, title: $title, description: $description, imageUrl: $imageUrl, siteName: $siteName, favicon: $favicon)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $LinkPreviewCopyWith<$Res>  {
+  factory $LinkPreviewCopyWith(LinkPreview value, $Res Function(LinkPreview) _then) = _$LinkPreviewCopyWithImpl;
+@useResult
+$Res call({
+ String url, String title, String? description, String? imageUrl, String? siteName, String? favicon
+});
+
+
+
+
+}
+/// @nodoc
+class _$LinkPreviewCopyWithImpl<$Res>
+    implements $LinkPreviewCopyWith<$Res> {
+  _$LinkPreviewCopyWithImpl(this._self, this._then);
+
+  final LinkPreview _self;
+  final $Res Function(LinkPreview) _then;
+
+/// Create a copy of LinkPreview
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? url = null,Object? title = null,Object? description = freezed,Object? imageUrl = freezed,Object? siteName = freezed,Object? favicon = freezed,}) {
+  return _then(_self.copyWith(
+url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,imageUrl: freezed == imageUrl ? _self.imageUrl : imageUrl // ignore: cast_nullable_to_non_nullable
+as String?,siteName: freezed == siteName ? _self.siteName : siteName // ignore: cast_nullable_to_non_nullable
+as String?,favicon: freezed == favicon ? _self.favicon : favicon // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [LinkPreview].
+extension LinkPreviewPatterns on LinkPreview {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _LinkPreview value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _LinkPreview() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _LinkPreview value)  $default,){
+final _that = this;
+switch (_that) {
+case _LinkPreview():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _LinkPreview value)?  $default,){
+final _that = this;
+switch (_that) {
+case _LinkPreview() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String url,  String title,  String? description,  String? imageUrl,  String? siteName,  String? favicon)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _LinkPreview() when $default != null:
+return $default(_that.url,_that.title,_that.description,_that.imageUrl,_that.siteName,_that.favicon);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String url,  String title,  String? description,  String? imageUrl,  String? siteName,  String? favicon)  $default,) {final _that = this;
+switch (_that) {
+case _LinkPreview():
+return $default(_that.url,_that.title,_that.description,_that.imageUrl,_that.siteName,_that.favicon);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String url,  String title,  String? description,  String? imageUrl,  String? siteName,  String? favicon)?  $default,) {final _that = this;
+switch (_that) {
+case _LinkPreview() when $default != null:
+return $default(_that.url,_that.title,_that.description,_that.imageUrl,_that.siteName,_that.favicon);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _LinkPreview implements LinkPreview {
+  const _LinkPreview({required this.url, required this.title, this.description, this.imageUrl, this.siteName, this.favicon});
+  factory _LinkPreview.fromJson(Map<String, dynamic> json) => _$LinkPreviewFromJson(json);
+
+/// The original URL
+@override final  String url;
+/// Page title (og:title or <title>)
+@override final  String title;
+/// Page description (og:description or meta description)
+@override final  String? description;
+/// Preview image URL (og:image)
+@override final  String? imageUrl;
+/// Site name (og:site_name or domain)
+@override final  String? siteName;
+/// Favicon URL
+@override final  String? favicon;
+
+/// Create a copy of LinkPreview
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$LinkPreviewCopyWith<_LinkPreview> get copyWith => __$LinkPreviewCopyWithImpl<_LinkPreview>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$LinkPreviewToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _LinkPreview&&(identical(other.url, url) || other.url == url)&&(identical(other.title, title) || other.title == title)&&(identical(other.description, description) || other.description == description)&&(identical(other.imageUrl, imageUrl) || other.imageUrl == imageUrl)&&(identical(other.siteName, siteName) || other.siteName == siteName)&&(identical(other.favicon, favicon) || other.favicon == favicon));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,url,title,description,imageUrl,siteName,favicon);
+
+@override
+String toString() {
+  return 'LinkPreview(url: $url, title: $title, description: $description, imageUrl: $imageUrl, siteName: $siteName, favicon: $favicon)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$LinkPreviewCopyWith<$Res> implements $LinkPreviewCopyWith<$Res> {
+  factory _$LinkPreviewCopyWith(_LinkPreview value, $Res Function(_LinkPreview) _then) = __$LinkPreviewCopyWithImpl;
+@override @useResult
+$Res call({
+ String url, String title, String? description, String? imageUrl, String? siteName, String? favicon
+});
+
+
+
+
+}
+/// @nodoc
+class __$LinkPreviewCopyWithImpl<$Res>
+    implements _$LinkPreviewCopyWith<$Res> {
+  __$LinkPreviewCopyWithImpl(this._self, this._then);
+
+  final _LinkPreview _self;
+  final $Res Function(_LinkPreview) _then;
+
+/// Create a copy of LinkPreview
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? url = null,Object? title = null,Object? description = freezed,Object? imageUrl = freezed,Object? siteName = freezed,Object? favicon = freezed,}) {
+  return _then(_LinkPreview(
+url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,imageUrl: freezed == imageUrl ? _self.imageUrl : imageUrl // ignore: cast_nullable_to_non_nullable
+as String?,siteName: freezed == siteName ? _self.siteName : siteName // ignore: cast_nullable_to_non_nullable
+as String?,favicon: freezed == favicon ? _self.favicon : favicon // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/messages/domain/link_preview.g.dart
+++ b/lib/features/messages/domain/link_preview.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'link_preview.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_LinkPreview _$LinkPreviewFromJson(Map<String, dynamic> json) => _LinkPreview(
+  url: json['url'] as String,
+  title: json['title'] as String,
+  description: json['description'] as String?,
+  imageUrl: json['imageUrl'] as String?,
+  siteName: json['siteName'] as String?,
+  favicon: json['favicon'] as String?,
+);
+
+Map<String, dynamic> _$LinkPreviewToJson(_LinkPreview instance) =>
+    <String, dynamic>{
+      'url': instance.url,
+      'title': instance.title,
+      'description': instance.description,
+      'imageUrl': instance.imageUrl,
+      'siteName': instance.siteName,
+      'favicon': instance.favicon,
+    };

--- a/lib/features/messages/ui/message_bubble.dart
+++ b/lib/features/messages/ui/message_bubble.dart
@@ -8,10 +8,12 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../../../features/contacts/data/roster_repository.dart';
 import '../../../features/rooms/data/room_subscription_service.dart';
+import '../data/link_preview_service.dart';
 import '../data/upload_progress_provider.dart';
 import '../domain/room_event.dart';
 import '../domain/upload_progress.dart';
 import 'read_receipt_indicator.dart';
+import 'widgets/link_preview_card.dart';
 import 'widgets/upload_progress_indicator.dart';
 import 'widgets/voice_message_player.dart';
 
@@ -385,14 +387,25 @@ class MessageBubble extends ConsumerWidget {
     final theme = Theme.of(context);
     final isDarkMode = theme.brightness == Brightness.dark;
 
-    return Text(
-      text,
-      style: TextStyle(
-        fontSize: 16,
-        height: 1.5,
-        color: _getTextColor(isMe, isDarkMode),
-        fontWeight: FontWeight.w400,
-      ),
+    // Check if text contains URLs for link preview
+    final hasUrls = LinkPreviewService.extractUrls(text).isNotEmpty;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          text,
+          style: TextStyle(
+            fontSize: 16,
+            height: 1.5,
+            color: _getTextColor(isMe, isDarkMode),
+            fontWeight: FontWeight.w400,
+          ),
+        ),
+        // Show link preview for the first URL in the message
+        if (hasUrls) InlineMessageLinkPreview(text: text, isOwnMessage: isMe),
+      ],
     );
   }
 

--- a/lib/features/messages/ui/widgets/link_preview_card.dart
+++ b/lib/features/messages/ui/widgets/link_preview_card.dart
@@ -1,0 +1,244 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../data/link_preview_service.dart';
+import '../../domain/link_preview.dart';
+
+/// Widget to display a link preview card in messages
+///
+/// Shows OpenGraph metadata including title, description, and image.
+/// Tappable to open the URL in an external browser.
+class LinkPreviewCard extends ConsumerWidget {
+  const LinkPreviewCard({
+    required this.url,
+    this.isOwnMessage = false,
+    super.key,
+  });
+
+  final String url;
+  final bool isOwnMessage;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final previewAsync = ref.watch(linkPreviewProvider(url));
+
+    return previewAsync.when(
+      data: (preview) {
+        if (preview == null) {
+          return const SizedBox.shrink();
+        }
+        return _buildPreviewCard(context, preview);
+      },
+      loading: () => _buildLoadingState(context),
+      error: (error, stack) => const SizedBox.shrink(),
+    );
+  }
+
+  Widget _buildLoadingState(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(top: 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            'Loading preview...',
+            style: TextStyle(
+              fontSize: 12,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPreviewCard(BuildContext context, LinkPreview preview) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    return GestureDetector(
+      onTap: () => _openUrl(preview.url),
+      child: Container(
+        margin: const EdgeInsets.only(top: 8),
+        constraints: const BoxConstraints(maxWidth: 280),
+        decoration: BoxDecoration(
+          color: isDark
+              ? theme.colorScheme.surfaceContainerHighest
+              : Colors.grey.shade100,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: isDark ? Colors.grey.shade700 : Colors.grey.shade300,
+          ),
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Preview image
+            if (preview.imageUrl != null && preview.imageUrl!.isNotEmpty)
+              AspectRatio(
+                aspectRatio: 1.91, // Standard OG image ratio
+                child: Image.network(
+                  preview.imageUrl!,
+                  fit: BoxFit.cover,
+                  errorBuilder: (context, error, stack) => Container(
+                    color: isDark ? Colors.grey.shade800 : Colors.grey.shade200,
+                    child: Icon(
+                      Icons.link,
+                      size: 32,
+                      color: isDark
+                          ? Colors.grey.shade600
+                          : Colors.grey.shade400,
+                    ),
+                  ),
+                  loadingBuilder: (context, child, progress) {
+                    if (progress == null) return child;
+                    return Container(
+                      color: isDark
+                          ? Colors.grey.shade800
+                          : Colors.grey.shade200,
+                      child: Center(
+                        child: CircularProgressIndicator(
+                          value: progress.expectedTotalBytes != null
+                              ? progress.cumulativeBytesLoaded /
+                                    progress.expectedTotalBytes!
+                              : null,
+                          strokeWidth: 2,
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+
+            // Content section
+            Padding(
+              padding: const EdgeInsets.all(10),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Site name with favicon
+                  Row(
+                    children: [
+                      if (preview.favicon != null &&
+                          preview.favicon!.isNotEmpty) ...[
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(2),
+                          child: Image.network(
+                            preview.favicon!,
+                            width: 14,
+                            height: 14,
+                            errorBuilder: (context, error, stack) => Icon(
+                              Icons.language,
+                              size: 14,
+                              color: theme.colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 6),
+                      ],
+                      Expanded(
+                        child: Text(
+                          preview.siteName ?? _getDomain(preview.url),
+                          style: TextStyle(
+                            fontSize: 11,
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+
+                  // Title
+                  Text(
+                    preview.title,
+                    style: TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                      color: theme.colorScheme.onSurface,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+
+                  // Description
+                  if (preview.description != null &&
+                      preview.description!.isNotEmpty) ...[
+                    const SizedBox(height: 4),
+                    Text(
+                      preview.description!,
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: theme.colorScheme.onSurfaceVariant,
+                        height: 1.3,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _getDomain(String url) {
+    try {
+      return Uri.parse(url).host;
+    } catch (_) {
+      return url;
+    }
+  }
+
+  Future<void> _openUrl(String url) async {
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+}
+
+/// Inline link preview that shows for the first URL in a text message
+class InlineMessageLinkPreview extends ConsumerWidget {
+  const InlineMessageLinkPreview({
+    required this.text,
+    this.isOwnMessage = false,
+    super.key,
+  });
+
+  final String text;
+  final bool isOwnMessage;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Extract first URL from text
+    final urls = LinkPreviewService.extractUrls(text);
+    if (urls.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return LinkPreviewCard(url: urls.first, isOwnMessage: isOwnMessage);
+  }
+}

--- a/test/features/messages/data/link_preview_service_test.dart
+++ b/test/features/messages/data/link_preview_service_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:stawi/features/messages/data/link_preview_service.dart';
+
+void main() {
+  group('LinkPreviewService', () {
+    group('extractUrls', () {
+      test('extracts single HTTP URL from text', () {
+        const text = 'Check out this link: http://example.com';
+        final urls = LinkPreviewService.extractUrls(text);
+        expect(urls, ['http://example.com']);
+      });
+
+      test('extracts single HTTPS URL from text', () {
+        const text = 'Check this: https://www.google.com/search?q=flutter';
+        final urls = LinkPreviewService.extractUrls(text);
+        expect(urls, ['https://www.google.com/search?q=flutter']);
+      });
+
+      test('extracts multiple URLs from text', () {
+        const text =
+            'Visit https://flutter.dev and https://dart.dev for documentation';
+        final urls = LinkPreviewService.extractUrls(text);
+        expect(urls, contains('https://flutter.dev'));
+        expect(urls, contains('https://dart.dev'));
+        expect(urls.length, 2);
+      });
+
+      test('returns empty list for text without URLs', () {
+        const text = 'This is just regular text without any links';
+        final urls = LinkPreviewService.extractUrls(text);
+        expect(urls, isEmpty);
+      });
+
+      test('handles URLs at the beginning of text', () {
+        const text = 'https://example.com is a great website';
+        final urls = LinkPreviewService.extractUrls(text);
+        expect(urls, ['https://example.com']);
+      });
+
+      test('handles URLs at the end of text', () {
+        const text = 'Great article at https://medium.com/article';
+        final urls = LinkPreviewService.extractUrls(text);
+        expect(urls, ['https://medium.com/article']);
+      });
+
+      test('handles URLs with path and query params', () {
+        const text = 'See https://example.com/path/to/page?id=123&ref=abc';
+        final urls = LinkPreviewService.extractUrls(text);
+        expect(urls, ['https://example.com/path/to/page?id=123&ref=abc']);
+      });
+
+      test('excludes PDF file URLs', () {
+        const text = 'Download the PDF: https://example.com/document.pdf';
+        final urls = LinkPreviewService.extractUrls(text);
+        expect(urls, isEmpty);
+      });
+
+      test('excludes ZIP file URLs', () {
+        const text = 'Download: https://example.com/archive.zip';
+        final urls = LinkPreviewService.extractUrls(text);
+        expect(urls, isEmpty);
+      });
+
+      test('excludes executable URLs', () {
+        const text = 'Don\'t download: https://example.com/app.exe';
+        final urls = LinkPreviewService.extractUrls(text);
+        expect(urls, isEmpty);
+      });
+
+      test('handles multiline text', () {
+        const text = '''
+First line
+Check https://example1.com
+Second line with https://example2.com
+Last line
+''';
+        final urls = LinkPreviewService.extractUrls(text);
+        expect(urls.length, 2);
+        expect(urls, contains('https://example1.com'));
+        expect(urls, contains('https://example2.com'));
+      });
+
+      test('handles URLs with fragments', () {
+        const text = 'Go to https://example.com/page#section';
+        final urls = LinkPreviewService.extractUrls(text);
+        expect(urls, ['https://example.com/page#section']);
+      });
+
+      test('handles URLs with port numbers', () {
+        const text = 'Dev server at http://localhost:8080/app';
+        final urls = LinkPreviewService.extractUrls(text);
+        expect(urls, ['http://localhost:8080/app']);
+      });
+
+      test('ignores partial URLs without scheme', () {
+        const text = 'Visit example.com or www.google.com';
+        final urls = LinkPreviewService.extractUrls(text);
+        expect(urls, isEmpty);
+      });
+    });
+
+    group('cache behavior', () {
+      late LinkPreviewService service;
+
+      setUp(() {
+        service = LinkPreviewService(() async => 'test-token');
+      });
+
+      test('clearCache removes all cached entries', () {
+        // This is a basic test - the cache is internal
+        // but clearCache should not throw
+        expect(() => service.clearCache(), returnsNormally);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add OpenGraph link preview for URLs shared in chat messages
- Auto-detect and display rich previews with title, description, and image
- Implement caching with 1-hour TTL and 5-second fetch timeout
- Integrate seamlessly into existing MessageBubble component

## Implementation Details

### New Files
- `lib/features/messages/data/link_preview_service.dart` - Service for fetching URL metadata
- `lib/features/messages/domain/link_preview.dart` - Freezed model for preview data
- `lib/features/messages/ui/widgets/link_preview_card.dart` - Rich preview card widget
- `test/features/messages/data/link_preview_service_test.dart` - Unit tests

### Modified Files
- `lib/features/messages/ui/message_bubble.dart` - Integrate link preview for text messages

### Features
- Server-side preview via files API with fallback to direct HTML parsing
- Supports og:title, og:description, og:image, og:site_name, and favicon
- Skip file types that don't have OpenGraph (PDF, ZIP, EXE, etc.)
- Graceful degradation on timeout or fetch failure
- Loading state indicator

## Test plan
- [x] Unit tests for URL extraction (15 test cases)
- [ ] Manual test: Send message with URL, verify preview loads
- [ ] Manual test: Verify preview opens correct URL when tapped
- [ ] Manual test: Verify fallback when server preview fails
- [ ] Manual test: Verify timeout handling

Closes #30

🤖 Generated with [Claude Code](https://claude.ai/code)